### PR TITLE
Security has energy guns now

### DIFF
--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -132,6 +132,8 @@
         orGroup: Guns
       - id: WeaponDisablerSMG
         orGroup: Guns
+      - id: WeaponEnergySMG
+        orGroup: Guns
       - id: WeaponTaser
         orGroup: Guns
       - id: WeaponAntiqueLaser

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -286,6 +286,16 @@
 
 - type: latheRecipe
   parent: BaseWeaponRecipeSidearm
+  id: WeaponEnergySMG
+  result: WeaponEnergySMG
+  materials:
+    Steel: 1500
+    Glass: 500
+    Plastic: 500
+    Gold: 100
+
+- type: latheRecipe
+  parent: BaseWeaponRecipeSidearm
   id: WeaponLaserSvalinn
   result: WeaponLaserSvalinn
   materials:

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -98,6 +98,7 @@
   - TelescopicShield
   - HoloprojectorSecurity
   - WeaponDisablerSMG
+  - WeaponEnergySMG
 
 - type: technology
   id: ExplosiveTechnology

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -227,8 +227,8 @@
     ears: ClothingHeadsetSecurity
     eyes: ClothingEyesGlassesSecurity
     outerClothing: ClothingOuterArmorBasic
-    pocket1: WeaponPistolMk58
-    pocket2: MagazinePistol
+    pocket1: WeaponEnergyGun # Changed from wizden
+#    pocket2: MagazinePistol
   inhand:
   - FlashlightSeclite
 
@@ -245,8 +245,8 @@
     ears: ClothingHeadsetSecurity
     eyes: ClothingEyesGlassesSecurity
     outerClothing: ClothingOuterArmorBasicSlim
-    pocket1: WeaponPistolMk58
-    pocket2: MagazinePistol
+    pocket1: WeaponEnergyGun # Changed from wizden
+#    pocket2: MagazinePistol
   inhand:
   - FlashlightSeclite
 
@@ -262,8 +262,8 @@
     ears: ClothingHeadsetSecurity
     eyes: ClothingEyesGlassesSecurity
     outerClothing: ClothingOuterArmorBasic
-    pocket1: WeaponPistolMk58
-    pocket2: MagazinePistol
+    pocket1: WeaponEnergyGun # Changed from wizden
+#    pocket2: MagazinePistol
   inhand:
   - FlashlightSeclite
 
@@ -280,8 +280,8 @@
     ears: ClothingHeadsetSecurity
     eyes: ClothingEyesGlassesSecurity
     outerClothing: ClothingOuterArmorBasicSlim
-    pocket1: WeaponPistolMk58
-    pocket2: MagazinePistol
+    pocket1: WeaponEnergyGun # Changed from wizden
+#    pocket2: MagazinePistol
   inhand:
   - FlashlightSeclite
 

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -33,12 +33,12 @@
     id: SecurityCadetPDA
     ears: ClothingHeadsetSecurity
     belt: ClothingBeltSecurityFilled
-    pocket1: WeaponPistolMk58
+    pocket1: WeaponEnergyGun # Changed from wizden
     pocket2: BookSecurity
   storage:
     back:
     - Flash
-    - MagazinePistol
+#    - MagazinePistol
 
 - type: chameleonOutfit
   id: SecurityCadetChameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -27,11 +27,11 @@
   equipment:
     eyes: ClothingEyesGlassesSecurity
     ears: ClothingHeadsetSecurity
-    pocket1: WeaponPistolMk58
+    pocket1: WeaponEnergyGun # Changed from wizden
   storage:
     back:
     - Flash
-    - MagazinePistol
+#    - MagazinePistol
 
 - type: chameleonOutfit
   id: SecurityOfficerChameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -34,11 +34,11 @@
     eyes: ClothingEyesGlassesSecurity
     id: WardenPDA
     ears: ClothingHeadsetSecurity
-    pocket1: WeaponPistolMk58
+    pocket1: WeaponEnergyGun # Changed from wizden
   storage:
     back:
     - Flash
-    - MagazinePistol
+#    - MagazinePistol
 
 - type: chameleonOutfit
   id: WardenChameleonOutfit

--- a/Resources/Prototypes/_lizloose/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_lizloose/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1,0 +1,33 @@
+- type: entity
+  name: energy gun
+  parent: [WeaponDisablerPractice, BaseSecurityCommandContraband]
+  id: WeaponEnergyGun
+  description: A self-defense weapon that exhausts organic targets, weakening them until they collapse.
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Battery/disabler.rsi
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-unshaded-0
+      map: ["enum.GunVisualLayers.MagUnshaded"]
+      shader: unshaded
+  - type: Clothing
+    sprite: Objects/Weapons/Guns/Battery/disabler.rsi
+    quickEquip: false
+    slots:
+    - suitStorage
+    - Belt
+  - type: ProjectileBatteryAmmoProvider
+    proto: BulletDisabler
+    fireCost: 62.5
+  - type: BatteryWeaponFireModes
+    fireModes:
+    - proto: BulletDisabler
+      fireCost: 62.5
+    - proto: BulletLaser
+      fireCost: 150
+  - type: GuideHelp
+    guides:
+    - Security
+    - Antagonists

--- a/Resources/Prototypes/_lizloose/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_lizloose/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -2,7 +2,7 @@
   name: energy gun
   parent: [WeaponDisablerPractice, BaseSecurityCommandContraband]
   id: WeaponEnergyGun
-  description: A self-defense weapon that exhausts organic targets, weakening them until they collapse.
+  description: A weapon with dual fire modes, for non-lethal stun bolts or lethal laser fire.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/disabler.rsi
@@ -26,8 +26,54 @@
     - proto: BulletDisabler
       fireCost: 62.5
     - proto: BulletLaser
-      fireCost: 150
+      fireCost: 125
   - type: GuideHelp
     guides:
     - Security
     - Antagonists
+
+- type: entity
+  name: Energy SMG
+  parent: [BaseWeaponBattery, BaseSecurityContraband]
+  id: WeaponEnergySMG
+  description: Advanced energy weapon that fires rapid bursts of non-lethal disabler bolts, with a secondary lethal laser fire mode.
+  components:
+  - type: Item
+    size: Large
+    shape:
+    - 0,0,2,1
+  - type: Tag
+    tags:
+    - Taser
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Battery/disabler_smg.rsi
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-unshaded-0
+      map: ["enum.GunVisualLayers.MagUnshaded"]
+      shader: unshaded
+  - type: Gun
+    selectedMode: FullAuto
+    fireRate: 4.5
+    availableModes:
+    - SemiAuto
+    - FullAuto
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
+  - type: ProjectileBatteryAmmoProvider
+    proto: BulletDisablerSmg
+    fireCost: 25
+  - type: BatteryWeaponFireModes
+    fireModes:
+    - proto: BulletDisablerSmg
+      fireCost: 25
+    - proto: BulletLaser
+      fireCost: 80
+  - type: MagazineVisuals
+    magState: mag
+    steps: 5
+    zeroVisible: true
+  - type: Appearance
+  - type: StaticPrice
+    price: 260


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
No more mk58, security officers now get energy guns. Basically a disabler/disabler smg with a lethal mode.

Disablers are still available from warden for pacifists. Need to make a loadout option or something to let people switch

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
security gun removal changes

gun bad

no balance yet working on feedback