### PR TITLE
migrate laser carbine

### DIFF
--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -20,6 +20,7 @@ GunSafePistolMk58: GunSafeDisabler
 CrateSecurityRiot : UMCrateSecurityRiot
 GunSafeLaserCarbine : UMGunSafeLaserCarbine
 WeaponDisabler: UMWeaponDisabler
+WeaponLaserCarbine:  UMWeaponLaserCarbine
 # Service
 WeaponShotgunDoubleBarreled : UMWeaponShotgunDoubleBarreled
 WeaponShotgunDoubleBarreledRubber: UMWeaponShotgunDoubleBarreled


### PR DESCRIPTION
some maps apparently still have old one so idk

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
last playtest someone said these were still wieldable so ima just migrate them 